### PR TITLE
Directly accessing gs and fs segment for PEB and TEB

### DIFF
--- a/Veil/Veil.System.Process.h
+++ b/Veil/Veil.System.Process.h
@@ -2505,13 +2505,23 @@ ZwResumeProcess(
 #define NtCurrentSession()      ((HANDLE)(LONG_PTR)-3)
 #define ZwCurrentSession()      NtCurrentSession()
 
-#define NtCurrentPeb()          (NtCurrentTeb()->ProcessEnvironmentBlock)
+#ifdef _M_X64
+#define NtCurrentPeb()          ((PEB *)__readgsqword(FIELD_OFFSET(TEB, ProcessEnvironmentBlock)))
+#elif _M_IX86
+#define NtCurrentPeb()          ((PEB *)__readfsdword(FIELD_OFFSET(TEB, ProcessEnvironmentBlock)))
+#endif
 #define ZwCurrentPeb()          NtCurrentPeb()
 
 // Not NT, but useful.
-#define NtCurrentProcessId()    (NtCurrentTeb()->ClientId.UniqueProcess)
+#ifdef _M_X64
+#define NtCurrentProcessId()    ((DWORD)__readgsdword(FIELD_OFFSET(TEB, ClientId.UniqueProcess)))
+#define NtCurrentThreadId()    ((DWORD)__readgsdword(FIELD_OFFSET(TEB, ClientId.UniqueThread)))
+#elif _M_IX86
+#define NtCurrentProcessId()    ((DWORD)__readfsdword(FIELD_OFFSET(TEB, ClientId.UniqueProcess)))
+#define NtCurrentThreadId()    ((DWORD)__readfsdword(FIELD_OFFSET(TEB, ClientId.UniqueThread)))
+#endif
+
 #define ZwCurrentProcessId()    NtCurrentProcessId()
-#define NtCurrentThreadId()     (NtCurrentTeb()->ClientId.UniqueThread)
 #define ZwCurrentThreadId()     NtCurrentThreadId()
 
 #endif // !_KERNEL_MODE


### PR DESCRIPTION
Instead of dereferencing \_TEB location, we can access gs / fs segment directly based on the offset.
Note : `GetStdHandle` accessing \_PEB directly (**gs:[0x60]**) instead of dereferencing \_TEB (**gs:[0x30]**) and then go to **0x60** offset.

This behaviour also has been discussed on Raymond Chen blogs.
[Why load fs:[0x18] into a register and then dereference that, instead of just going for fs:[n] directly?](https://devblogs.microsoft.com/oldnewthing/20220919-00/?p=107195)