### PR TITLE
fix: Warning C4819

### DIFF
--- a/Veil/Veil.System.SMBios.h
+++ b/Veil/Veil.System.SMBios.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * PROJECT:   Veil
  * FILE:      Veil.System.SMBios.h
  * PURPOSE:   This file is part of Veil.


### PR DESCRIPTION
Veil.System.SMBios.h(667,1): Warning C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失